### PR TITLE
add citation to data used in diversity article

### DIFF
--- a/vignettes/bibliography.bib
+++ b/vignettes/bibliography.bib
@@ -424,6 +424,17 @@
   pagetotal = {160}
 }
 
+@article{lipo2015theoretically,
+  title={A theoretically-sufficient and computationally-practical technique for deterministic frequency seriation},
+  author={Lipo, Carl P and Madsen, Mark E and Dunnell, Robert C},
+  journal={PLOS one},
+  volume={10},
+  number={4},
+  pages={e0124942},
+  year={2015},
+  publisher={Public Library of Science San Francisco, CA USA}
+}
+
 @article{macarthur1965,
   title = {Patterns of {{Species Diversity}}},
   author = {Macarthur, Robert H.},

--- a/vignettes/diversity.Rmd
+++ b/vignettes/diversity.Rmd
@@ -136,6 +136,9 @@ $$ \hat{\gamma}^2_{infreq} = \max\left[\frac{\hat{S}_{infreq}}{\hat{C}_{infreq}}
 Where $m_{infreq}$ is the number of sampling units that include at least one infrequent species.
 
 ### Usage
+
+To demonstrate how to use these diversity functions we will use a dataset containing ceramic counts from the Mississippi region, originally published by @lipo2015theoretically.
+
 ```{r richness}
 richness(mississippi, method = "margalef")
 ```


### PR DESCRIPTION
## Description
I've added a citation to the data used in the diversity article. I think this is important for two reasons: (1) to give credit to the data producers, in this case @clipo, and show others that publishing data is rewarded by visibility through citation, and (2) to give archaeological context to the example so it's easier for the novice reader to understand how the example works.

